### PR TITLE
add code style check to github workflow.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,12 @@
 name: build
 
 on:
-  # the workflow is triggered on push to any branch
-  # or when any pullrequest is opened.
   push:
+    branches:
+      - master
   pull_request:
+    branches:
+      - master
 
 env:
   BUILD_TYPE: Release
@@ -44,8 +46,3 @@ jobs:
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: ctest --build-config $BUILD_TYPE
-
-      - name: Check Style
-        shell: bash
-        working-directory: ${{runner.workspace}}/build
-        run: cmake --build . --config $BUILD_TYPE --target check_style

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -1,0 +1,49 @@
+# Copyright (c)  2020  Fangjun Kuang (csukuangfj@gmail.com)
+
+# See ../../LICENSE for clarification regarding multiple authors
+
+name: style_check
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install cpplint==1.4.5
+
+      - name: Create Build Directory
+        run: cmake -E make_directory ${{runner.workspace}}/build
+
+      - name: Configure CMake
+        shell: bash
+        working-directory: ${{runner.workspace}}/build
+        run: cmake -DCMAKE_CXX_CPPLINT=cpplint $GITHUB_WORKSPACE
+
+      - name: Check style
+        shell: bash
+        working-directory: ${{runner.workspace}}/build
+        # it will build all targets; while building a library, it
+        # invokes cpplint automatically to check the corresponding
+        # cc source file. If it find any errors, the return code will be 1.
+        run: cmake --build . 2>&1 | awk '/errors/ {exit 1} {print $0}'

--- a/cmake/cpplint.cmake
+++ b/cmake/cpplint.cmake
@@ -10,7 +10,7 @@ function(download_cpplint)
   set(cpplint_DIR "${k2_THIRD_PARTY_DIR}/cpplint")
 
   ExternalProject_Add(
-    cpplint
+    cpplint_py
     URL                 ${cpplint_URL}
     TIMEOUT             10
     PREFIX              ${cpplint_DIR}
@@ -31,4 +31,4 @@ add_custom_target(check_style
   COMMAND
     ${CMAKE_SOURCE_DIR}/scripts/check_style_cpplint.sh ${CMAKE_BINARY_DIR} 1
 )
-add_dependencies(check_style cpplint)
+add_dependencies(check_style cpplint_py)

--- a/scripts/check_style_cpplint.sh
+++ b/scripts/check_style_cpplint.sh
@@ -35,7 +35,7 @@ else
   # is downloaded automatically when the project is configured.
   build_dir=$k2_dir/build
 fi
-cpplint_src=$build_dir/third_party/cpplint/src/cpplint/cpplint.py
+cpplint_src=$build_dir/third_party/cpplint/src/cpplint_py/cpplint.py
 
 function ok() {
   printf "${bold}${green}[OK]${default} $1\n"


### PR DESCRIPTION
We use `cmake -DCMAKE_CXX_CPPLINT=cpplint ..` to invoke
cpplint when the command `make` is executed.

Not sure why your GitHub actions failed.

I've tested it on my master branch;  GitHub workflow will exit with error code 1 if
cpplint finds an error.  For example, this pullrequest (https://github.com/csukuangfj/k2/pull/3/checks?check_run_id=612592677) fails in the check;

whereas this pullrequest (https://github.com/csukuangfj/k2/pull/2/checks) passes in the check.