### PR TITLE
visualize FSA via GraphViz.

### DIFF
--- a/k2/csrc/CMakeLists.txt
+++ b/k2/csrc/CMakeLists.txt
@@ -6,6 +6,10 @@ add_library(fsa_util fsa_util.cc)
 target_include_directories(fsa_util PUBLIC ${CMAKE_SOURCE_DIR})
 target_compile_features(fsa_util PUBLIC cxx_std_11)
 
+add_library(fsa_renderer fsa_renderer.cc)
+target_include_directories(fsa_renderer PUBLIC ${CMAKE_SOURCE_DIR})
+target_compile_features(fsa_renderer PUBLIC cxx_std_11)
+
 add_executable(properties_test properties_test.cc)
 
 target_link_libraries(properties_test
@@ -32,6 +36,20 @@ target_link_libraries(fsa_util_test
 add_test(NAME Test.fsa_util_test
   COMMAND
     $<TARGET_FILE:fsa_util_test>
+)
+
+add_executable(fsa_renderer_test fsa_renderer_test.cc)
+
+target_link_libraries(fsa_renderer_test
+  PRIVATE
+    fsa_renderer
+    gtest
+    gtest_main
+)
+
+add_test(NAME Test.fsa_renderer_test
+  COMMAND
+    $<TARGET_FILE:fsa_renderer_test>
 )
 
 # TODO(fangjun): write some helper functions to create targets.

--- a/k2/csrc/fsa_renderer.cc
+++ b/k2/csrc/fsa_renderer.cc
@@ -1,0 +1,85 @@
+// k2/csrc/fsa_renderer.cc
+
+// Copyright (c)  2020  Fangjun Kuang (csukuangfj@gmail.com)
+
+// See ../../LICENSE for clarification regarding multiple authors
+
+#include "k2/csrc/fsa_renderer.h"
+
+#include <sstream>
+#include <string>
+
+namespace {
+
+std::string GeneratePrologue() {
+  // TODO(fangjun): the following options can be passed from outside
+  std::string header = R"header(
+digraph FSA {
+  rankdir = LR;
+  size = "8.5,11";
+  label = "";
+  center = 1;
+  orientation = Portrait;
+  ranksep = "0.4"
+  nodesep = "0.25"
+)header";
+  return header;
+}
+
+std::string GenerateEpilogue() { return "}"; }
+
+using k2::Arc;
+using k2::Fsa;
+using k2::Label;
+using k2::StateId;
+
+std::string ProcessState(const Fsa &fsa, int32_t state) {
+  std::ostringstream os;
+  os << "  " << state << " [label = \"" << state
+     << "\", shape = circle, style = bold, fontsize=14]"
+     << "\n";
+
+  int32_t begin = fsa.leaving_arcs[state].begin;
+  int32_t end = fsa.leaving_arcs[state].end;
+
+  for (; begin != end; ++begin) {
+    const auto &arc = fsa.arcs[begin];
+    StateId src = arc.src_state;
+    StateId dest = arc.dest_state;
+    Label label = arc.label;
+    os << "          " << src << " -> " << dest << " [label = \"" << label
+       << "\", fontsize = 14];"
+       << "\n";
+  }
+
+  return os.str();
+}
+
+}  // namespace
+
+namespace k2 {
+
+FsaRenderer::FsaRenderer(const Fsa &fsa) : fsa_(fsa) {}
+
+std::string FsaRenderer::Render() const {
+  int32_t num_states = fsa_.NumStates();
+  if (num_states == 0) return "";
+
+  std::ostringstream os;
+  os << GeneratePrologue();
+
+  for (int32_t i = 0; i != num_states - 1; ++i) {
+    os << ProcessState(fsa_, i);
+  }
+
+  // now for the final state
+  os << "  " << (num_states - 1) << " [label = \"" << (num_states - 1)
+     << "\", shape = doublecircle, style = solid, fontsize = 14]"
+     << "\n";
+
+  os << GenerateEpilogue() << "\n";
+
+  return os.str();
+}
+
+}  // namespace k2

--- a/k2/csrc/fsa_renderer.h
+++ b/k2/csrc/fsa_renderer.h
@@ -1,0 +1,30 @@
+// k2/csrc/fsa_renderer.h
+
+// Copyright (c)  2020  Fangjun Kuang (csukuangfj@gmail.com)
+
+// See ../../LICENSE for clarification regarding multiple authors
+
+#include <string>
+
+#include "k2/csrc/fsa.h"
+
+#ifndef K2_CSRC_FSA_RENDERER_H_
+#define K2_CSRC_FSA_RENDERER_H_
+
+namespace k2 {
+
+// Get a GraphViz representation of an fsa.
+class FsaRenderer {
+ public:
+  explicit FsaRenderer(const Fsa &fsa);
+
+  // Return a GraphViz representation of the fsa
+  std::string Render() const;
+
+ private:
+  const Fsa &fsa_;
+};
+
+}  // namespace k2
+
+#endif  // K2_CSRC_FSA_RENDERER_H_

--- a/k2/csrc/fsa_renderer_test.cc
+++ b/k2/csrc/fsa_renderer_test.cc
@@ -1,0 +1,42 @@
+// k2/csrc/fsa_renderer_test.cc
+
+// Copyright (c)  2020  Fangjun Kuang (csukuangfj@gmail.com)
+
+// See ../../LICENSE for clarification regarding multiple authors
+
+#include "k2/csrc/fsa_renderer.h"
+
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace k2 {
+
+// NOTE(fangjun): this test always passes.
+// Its purpose is to get a Graphviz representation
+// of the fsa and convert it to a viewable format **offline**.
+//
+// For example, you can run
+//
+//  ./k2/csrc/fsa_renderer_test 2>&1 >/dev/null | dot -Tpdf > test.pdf
+//
+// and then open the generated "test.pdf" to verify FsaRenderer works
+// as expected.
+TEST(FsaRenderer, Render) {
+  std::vector<Arc> arcs = {
+      {0, 1, 2}, {0, 2, 1}, {1, 2, 0}, {1, 3, 5}, {2, 3, 6},
+  };
+  std::vector<Range> leaving_arcs = {
+      {0, 2}, {2, 4}, {4, 5}, {0, 0},  // the last state has no leaving arcs
+  };
+
+  Fsa fsa;
+  fsa.leaving_arcs = std::move(leaving_arcs);
+  fsa.arcs = std::move(arcs);
+
+  FsaRenderer renderer(fsa);
+  std::cerr << renderer.Render();
+}
+
+}  // namespace k2

--- a/k2/csrc/fsa_util.cc
+++ b/k2/csrc/fsa_util.cc
@@ -14,9 +14,9 @@ namespace k2 {
 void GetEnteringArcs(const Fsa &fsa, VecOfVec *entering_arcs) {
   // CHECK(CheckProperties(fsa, KTopSorted));
 
-  int num_states = fsa.NumStates();
+  int32_t num_states = fsa.NumStates();
   std::vector<std::vector<std::pair<Label, StateId>>> vec(num_states);
-  int num_arcs = 0;
+  int32_t num_arcs = 0;
   for (const auto &arc : fsa.arcs) {
     auto src_state = arc.src_state;
     auto dest_state = arc.dest_state;
@@ -27,6 +27,8 @@ void GetEnteringArcs(const Fsa &fsa, VecOfVec *entering_arcs) {
 
   auto &ranges = entering_arcs->ranges;
   auto &values = entering_arcs->values;
+  ranges.clear();
+  values.clear();
   ranges.reserve(num_states);
   values.reserve(num_arcs);
 

--- a/k2/csrc/fsa_util_test.cc
+++ b/k2/csrc/fsa_util_test.cc
@@ -18,7 +18,7 @@ TEST(FsaUtil, GetEnteringArcs) {
       {0, 1, 2}, {0, 2, 1}, {1, 2, 0}, {1, 3, 5}, {2, 3, 6},
   };
   std::vector<Range> leaving_arcs = {
-      {0, 2}, {2, 4}, {4, 5}, {0, 0},  // the last state has no entering arcs
+      {0, 2}, {2, 4}, {4, 5}, {0, 0},  // the last state has no leaving arcs
   };
 
   Fsa fsa;


### PR DESCRIPTION
I know it's difficult, if not impossible, to visualize an FSA with lots of states and transitions.

Visualization can be helpful to debug later algorithms, such as epsilon removal, trim, determinization ... ...

-----


Visualization of the following fsa is given below.

```cpp
  std::vector<Arc> arcs = {
      {0, 1, 2}, {0, 2, 1}, {1, 2, 0}, {1, 3, 5}, {2, 3, 6},
  };
  std::vector<Range> leaving_arcs = {
      {0, 2}, {2, 4}, {4, 5}, {0, 0},  // the last state has no leaving arcs
  };
```

![abc](https://user-images.githubusercontent.com/5284924/80270503-533a7d00-86eb-11ea-84e6-2778b22c4af9.png)

It is obtained by

```bash
./k2/csrc/fsa_renderer_test 2>&1 >/dev/null | dot -Tpng > abc.png
```