### PR TITLE
implement Connect.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,15 @@ set(k2_THIRD_PARTY_DIR "${CMAKE_BINARY_DIR}/third_party" CACHE STRING
   "Directory to save & build downloaded third party libraries"
 )
 
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Set the build type" FORCE)
+endif()
+
 enable_testing()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 include(googletest)
+include(glog)
 include(cpplint)
 
 add_subdirectory(k2)

--- a/cmake/glog.cmake
+++ b/cmake/glog.cmake
@@ -1,0 +1,43 @@
+# Copyright (c) 2020 Fangjun Kuang (csukuangfj@gmail.com)
+# See ../LICENSE for clarification regarding multiple authors
+
+function(download_glog)
+  include(ExternalProject)
+
+  set(glog_URL  "https://github.com/google/glog/archive/v0.4.0.tar.gz")
+  set(glog_HASH "sha256=f28359aeba12f30d73d9e4711ef356dc842886968112162bc73002645139c39c")
+
+  set(glog_DIR  "${k2_THIRD_PARTY_DIR}/glog")
+  set(glog_INSTALL_DIR  "${glog_DIR}/install")
+
+  if(WIN32)
+    set(glog_libglog "${glog_INSTALL_DIR}/lib/glog.lib")
+  else()
+    set(glog_libglog "${glog_INSTALL_DIR}/lib/libglog.a")
+  endif()
+
+  set(glog_INCLUDE_DIR "${glog_INSTALL_DIR}/include")
+  file(MAKE_DIRECTORY ${glog_INCLUDE_DIR})
+
+  ExternalProject_Add(
+    glog_glog
+    URL               ${glog_URL}
+    PREFIX            ${glog_DIR}
+    INSTALL_DIR       ${glog_DIR/install}
+    CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=${glog_INSTALL_DIR}
+                      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                      -DWITH_GFLAGS=OFF
+                      -DWITH_THREADS=ON
+                      -DWITH_TLS=ON
+                      -DBUILD_SHARED_LIBS=OFF
+    LOG_DOWNLOAD      ON
+    LOG_CONFIGURE     ON
+  )
+
+  add_library(glog STATIC IMPORTED GLOBAL)
+  set_property(TARGET glog PROPERTY IMPORTED_LOCATION ${glog_libglog})
+  target_include_directories(glog INTERFACE ${glog_INCLUDE_DIR})
+  add_dependencies(glog glog_glog)
+endfunction()
+
+download_glog()

--- a/k2/csrc/CMakeLists.txt
+++ b/k2/csrc/CMakeLists.txt
@@ -13,6 +13,7 @@ target_compile_features(fsa_renderer PUBLIC cxx_std_11)
 add_library(fsa_algo fsa_algo.cc)
 target_include_directories(fsa_algo PUBLIC ${CMAKE_SOURCE_DIR})
 target_compile_features(fsa_algo PUBLIC cxx_std_11)
+target_link_libraries(fsa_algo PRIVATE glog)
 
 add_executable(properties_test properties_test.cc)
 
@@ -61,7 +62,6 @@ add_executable(fsa_algo_test fsa_algo_test.cc)
 target_link_libraries(fsa_algo_test
   PRIVATE
     fsa_algo
-    fsa_renderer
     gtest
     gtest_main
 )

--- a/k2/csrc/CMakeLists.txt
+++ b/k2/csrc/CMakeLists.txt
@@ -10,6 +10,10 @@ add_library(fsa_renderer fsa_renderer.cc)
 target_include_directories(fsa_renderer PUBLIC ${CMAKE_SOURCE_DIR})
 target_compile_features(fsa_renderer PUBLIC cxx_std_11)
 
+add_library(fsa_algo fsa_algo.cc)
+target_include_directories(fsa_algo PUBLIC ${CMAKE_SOURCE_DIR})
+target_compile_features(fsa_algo PUBLIC cxx_std_11)
+
 add_executable(properties_test properties_test.cc)
 
 target_link_libraries(properties_test
@@ -50,6 +54,21 @@ target_link_libraries(fsa_renderer_test
 add_test(NAME Test.fsa_renderer_test
   COMMAND
     $<TARGET_FILE:fsa_renderer_test>
+)
+
+add_executable(fsa_algo_test fsa_algo_test.cc)
+
+target_link_libraries(fsa_algo_test
+  PRIVATE
+    fsa_algo
+    fsa_renderer
+    gtest
+    gtest_main
+)
+
+add_test(NAME Test.fsa_algo_test
+  COMMAND
+    $<TARGET_FILE:fsa_algo_test>
 )
 
 # TODO(fangjun): write some helper functions to create targets.

--- a/k2/csrc/CMakeLists.txt
+++ b/k2/csrc/CMakeLists.txt
@@ -61,6 +61,7 @@ add_executable(fsa_algo_test fsa_algo_test.cc)
 target_link_libraries(fsa_algo_test
   PRIVATE
     fsa_algo
+    fsa_renderer
     gtest
     gtest_main
 )

--- a/k2/csrc/CMakeLists.txt
+++ b/k2/csrc/CMakeLists.txt
@@ -61,7 +61,6 @@ add_executable(fsa_algo_test fsa_algo_test.cc)
 target_link_libraries(fsa_algo_test
   PRIVATE
     fsa_algo
-    fsa_renderer
     gtest
     gtest_main
 )

--- a/k2/csrc/fsa.h
+++ b/k2/csrc/fsa.h
@@ -18,12 +18,11 @@ using StateId = int32_t;
 using Weight = float;
 
 enum {
-  kFinalSymbol = -1,     // final-costs are represented as arcs with
-                         // kFinalSymbol as their label, to the final
-                         // state (see Fst::final_state).
-  kEpsilon = 0,          // Epsilon, which means "no symbol", is numbered zero,
-                         // like in OpenFst.
-  kInvalidStateId = -1,  // it MUST be less than zero, like in OpenFst.
+  kFinalSymbol = -1,  // final-costs are represented as arcs with
+                      // kFinalSymbol as their label, to the final
+                      // state (see Fst::final_state).
+  kEpsilon = 0,       // Epsilon, which means "no symbol", is numbered zero,
+                      // like in OpenFst.
 };
 
 struct Arc {

--- a/k2/csrc/fsa.h
+++ b/k2/csrc/fsa.h
@@ -18,11 +18,12 @@ using StateId = int32_t;
 using Weight = float;
 
 enum {
-  kFinalSymbol = -1,  // final-costs are represented as arcs with
-                      // kFinalSymbol as their label, to the final
-                      // state (see Fst::final_state).
-  kEpsilon = 0        // Epsilon, which means "no symbol", is numbered zero,
-                      // like in OpenFst.
+  kFinalSymbol = -1,     // final-costs are represented as arcs with
+                         // kFinalSymbol as their label, to the final
+                         // state (see Fst::final_state).
+  kEpsilon = 0,          // Epsilon, which means "no symbol", is numbered zero,
+                         // like in OpenFst.
+  kInvalidStateId = -1,  // it MUST be less than zero, like in OpenFst.
 };
 
 struct Arc {

--- a/k2/csrc/fsa_algo.cc
+++ b/k2/csrc/fsa_algo.cc
@@ -6,8 +6,6 @@
 
 #include "k2/csrc/fsa_algo.h"
 
-#include <iostream>
-#include <sstream>
 #include <stack>
 
 namespace {
@@ -82,22 +80,14 @@ void ConnectCore(const Fsa &fsa, std::vector<int32_t> *state_map) {
     }
   }
 
-  // TODO(fangjun): remove states that are not accessible or coaccessible;
-  // the following is for debug purpose only
-  int32_t i = 0;
-  std::ostringstream os;
-  for (const auto b : accessible) {
-    if (!b) os << "state " << i << " is not accessible\n";
-    ++i;
-  }
+  state_map->clear();
+  state_map->reserve(num_states);
 
-  i = 0;
-  for (const auto b : coaccessible) {
-    if (!b) os << "state " << i << " is not coaccessible\n";
-    ++i;
+  for (int32_t i = 0; i != num_states; ++i) {
+    if (accessible[i] && coaccessible[i]) {
+      state_map->push_back(i);
+    }
   }
-
-  std::cout << os.str() << "\n";
 }
 
 }  // namespace k2

--- a/k2/csrc/fsa_algo.cc
+++ b/k2/csrc/fsa_algo.cc
@@ -1,0 +1,103 @@
+// k2/csrc/fsa_algo.cc
+
+// Copyright (c)  2020  Fangjun Kuang (csukuangfj@gmail.com)
+
+// See ../../LICENSE for clarification regarding multiple authors
+
+#include "k2/csrc/fsa_algo.h"
+
+#include <iostream>
+#include <sstream>
+#include <stack>
+
+namespace {
+
+// depth first search state
+struct DfsState {
+  int32_t s;      // state number of the visiting node
+  int32_t begin;  // arc index of the visiting arc
+  int32_t end;    // end of the arc index of the visiting node
+};
+
+}  // namespace
+
+namespace k2 {
+
+// The implementation of this function is inspired by
+// http://www.openfst.org/doxygen/fst/html/connect_8h_source.html
+void ConnectCore(const Fsa &fsa, std::vector<int32_t> *state_map) {
+  if (IsEmpty(fsa)) return;
+
+  auto num_states = fsa.NumStates();
+  auto final_state = num_states - 1;
+
+  std::vector<bool> accessible(num_states, false);
+  std::vector<bool> coaccessible(num_states, false);
+  std::vector<bool> visited(num_states, false);
+
+  accessible.front() = true;
+  coaccessible.back() = true;
+
+  std::stack<DfsState> stack;
+  stack.push({0, fsa.arc_indexes[0], fsa.arc_indexes[1]});
+  visited[0] = true;
+
+  while (!stack.empty()) {
+    auto &top = stack.top();
+
+    if (top.begin == top.end) {
+      // we have finished visiting this state
+      auto s = top.s;  // get a copy since we will destroy it
+      stack.pop();
+      if (!stack.empty()) {
+        // if it has a parent, set the parent's coaccessible flag
+        if (coaccessible[s]) {
+          auto &parent = stack.top();
+          coaccessible[parent.s] = true;
+          ++parent.begin;  // process the next child
+        }
+      }
+      continue;
+    }
+
+    const auto &arc = fsa.arcs[top.begin];
+    auto next_state = arc.dest_state;
+    bool is_visited = visited[next_state];
+    if (!is_visited) {
+      // this is a new discovered state
+      visited[next_state] = true;
+      auto begin = fsa.arc_indexes[next_state];
+      if (next_state != final_state)
+        stack.push({next_state, begin, fsa.arc_indexes[next_state + 1]});
+      else
+        stack.push({next_state, begin, begin});
+
+      if (accessible[top.s]) accessible[next_state] = true;
+    } else {
+      // this is a back arc or forward cross arc;
+      // update the coaccesible flag
+      auto next_state = arc.dest_state;
+      if (coaccessible[next_state]) coaccessible[top.s] = true;
+      ++top.begin;  // go to the next arc
+    }
+  }
+
+  // TODO(fangjun): remove states that are not accessible or coaccessible;
+  // the following is for debug purpose only
+  int32_t i = 0;
+  std::ostringstream os;
+  for (const auto b : accessible) {
+    if (!b) os << "state " << i << " is not accessible\n";
+    ++i;
+  }
+
+  i = 0;
+  for (const auto b : coaccessible) {
+    if (!b) os << "state " << i << " is not coaccessible\n";
+    ++i;
+  }
+
+  std::cout << os.str() << "\n";
+}
+
+}  // namespace k2

--- a/k2/csrc/fsa_algo.h
+++ b/k2/csrc/fsa_algo.h
@@ -128,7 +128,7 @@ void Connect(const Fsa &a, Fsa *b, std::vector<int32_t> *arc_map = nullptr);
 void RmEpsilonsPruned(const WfsaWithFbWeights &a,
                       float beam,
                       Fsa *b,
-                      std::vector<std::vector<Arc>> *arc_map);
+                      std::vector<std::vector<int32_t>> *arc_map);
 
 
 /*

--- a/k2/csrc/fsa_algo.h
+++ b/k2/csrc/fsa_algo.h
@@ -4,12 +4,13 @@
 
 // See ../../LICENSE for clarification regarding multiple authors
 
+#ifndef K2_CSRC_FSA_ALGO_H_
+#define K2_CSRC_FSA_ALGO_H_
+
 #include <vector>
 
 #include "k2/csrc/fsa.h"
-
-#ifndef K2_CSRC_FSA_ALGO_H_
-#define K2_CSRC_FSA_ALGO_H_
+#include "k2/csrc/weights.h"
 
 namespace k2 {
 
@@ -127,7 +128,7 @@ void Connect(const Fsa &a, Fsa *b, std::vector<int32_t> *arc_map = nullptr);
 void RmEpsilonsPruned(const WfsaWithFbWeights &a,
                       float beam,
                       Fsa *b,
-                      std::vector<std::vector> *arc_map);
+                      std::vector<std::vector<Arc>> *arc_map);
 
 
 /*

--- a/k2/csrc/fsa_algo_test.cc
+++ b/k2/csrc/fsa_algo_test.cc
@@ -1,0 +1,36 @@
+// k2/csrc/fsa_algo_test.cc
+
+// Copyright (c)  2020  Fangjun Kuang (csukuangfj@gmail.com)
+
+// See ../../LICENSE for clarification regarding multiple authors
+
+#include "k2/csrc/fsa_algo.h"
+
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "k2/csrc/fsa_renderer.h"
+
+namespace k2 {
+
+TEST(FsaAlgo, Connect) {
+  std::vector<Arc> arcs = {
+      {0, 1, 1}, {0, 2, 2}, {1, 3, 3}, {1, 6, 6},
+      {2, 4, 2}, {2, 6, 3}, {5, 0, 1},
+  };
+
+  std::vector<int32_t> arc_indexes = {0, 2, 4, 6, 6, 6, 7};
+
+  Fsa fsa;
+  fsa.arc_indexes = std::move(arc_indexes);
+  fsa.arcs = std::move(arcs);
+
+  ConnectCore(fsa, nullptr);
+
+  // for debug only
+  FsaRenderer renderer(fsa);
+  std::cerr << renderer.Render();
+}
+
+}  // namespace k2

--- a/k2/csrc/fsa_algo_test.cc
+++ b/k2/csrc/fsa_algo_test.cc
@@ -10,11 +10,10 @@
 #include <vector>
 
 #include "gtest/gtest.h"
-#include "k2/csrc/fsa_renderer.h"
 
 namespace k2 {
 
-TEST(FsaAlgo, Connect) {
+TEST(FsaAlgo, ConnectCore) {
   std::vector<Arc> arcs = {
       {0, 1, 1}, {0, 2, 2}, {1, 3, 3}, {1, 6, 6},
       {2, 4, 2}, {2, 6, 3}, {5, 0, 1},
@@ -26,11 +25,13 @@ TEST(FsaAlgo, Connect) {
   fsa.arc_indexes = std::move(arc_indexes);
   fsa.arcs = std::move(arcs);
 
-  ConnectCore(fsa, nullptr);
-
-  // for debug only
-  FsaRenderer renderer(fsa);
-  std::cerr << renderer.Render();
+  std::vector<int32_t> state_map;
+  ConnectCore(fsa, &state_map);
+  int k = 0;
+  for (auto i : state_map) {
+    std::cout << k << " -> " << i << "\n";
+    ++k;
+  }
 }
 
 }  // namespace k2

--- a/k2/csrc/fsa_algo_test.cc
+++ b/k2/csrc/fsa_algo_test.cc
@@ -10,10 +10,11 @@
 #include <vector>
 
 #include "gtest/gtest.h"
+#include "k2/csrc/fsa_renderer.h"
 
 namespace k2 {
 
-TEST(FsaAlgo, ConnectCore) {
+TEST(FsaAlgo, Connect) {
   std::vector<Arc> arcs = {
       {0, 1, 1}, {0, 2, 2}, {1, 3, 3}, {1, 6, 6},
       {2, 4, 2}, {2, 6, 3}, {5, 0, 1},
@@ -21,16 +22,35 @@ TEST(FsaAlgo, ConnectCore) {
 
   std::vector<int32_t> arc_indexes = {0, 2, 4, 6, 6, 6, 7};
 
-  Fsa fsa;
-  fsa.arc_indexes = std::move(arc_indexes);
-  fsa.arcs = std::move(arcs);
+  {
+    Fsa fsa;
+    std::vector<int32_t> state_map(10);  // an arbitray number
+    ConnectCore(fsa, &state_map);
+    EXPECT_TRUE(state_map.empty());
+  }
 
-  std::vector<int32_t> state_map;
-  ConnectCore(fsa, &state_map);
-  int k = 0;
-  for (auto i : state_map) {
-    std::cout << k << " -> " << i << "\n";
-    ++k;
+  {
+    Fsa fsa;
+    fsa.arc_indexes = std::move(arc_indexes);
+    fsa.arcs = std::move(arcs);
+
+    std::vector<int32_t> state_map(10);  // an arbitray number
+    ConnectCore(fsa, &state_map);
+
+    EXPECT_EQ(state_map.size(), 4u);
+    EXPECT_EQ(state_map[0], 0);
+    EXPECT_EQ(state_map[1], 1);
+    EXPECT_EQ(state_map[2], 2);
+    EXPECT_EQ(state_map[3], 6);
+
+    Fsa connected;
+    Connect(fsa, &connected, nullptr);
+    FsaRenderer renderer(connected);
+    std::cerr << renderer.Render();
+    // TODO(fangjun): check number of sates of "connected"
+    // and check its arcs.
+    //
+    // Check arc_map
   }
 }
 

--- a/k2/csrc/fsa_algo_test.cc
+++ b/k2/csrc/fsa_algo_test.cc
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "gtest/gtest.h"
-#include "k2/csrc/fsa_renderer.h"
 
 namespace k2 {
 
@@ -24,7 +23,7 @@ TEST(FsaAlgo, Connect) {
 
   {
     Fsa fsa;
-    std::vector<int32_t> state_map(10);  // an arbitray number
+    std::vector<int32_t> state_map(10);  // an arbitrary number
     ConnectCore(fsa, &state_map);
     EXPECT_TRUE(state_map.empty());
   }
@@ -34,7 +33,7 @@ TEST(FsaAlgo, Connect) {
     fsa.arc_indexes = std::move(arc_indexes);
     fsa.arcs = std::move(arcs);
 
-    std::vector<int32_t> state_map(10);  // an arbitray number
+    std::vector<int32_t> state_map(10);  // an arbitrary number
     ConnectCore(fsa, &state_map);
 
     EXPECT_EQ(state_map.size(), 4u);
@@ -44,13 +43,36 @@ TEST(FsaAlgo, Connect) {
     EXPECT_EQ(state_map[3], 6);
 
     Fsa connected;
-    Connect(fsa, &connected, nullptr);
-    FsaRenderer renderer(connected);
-    std::cerr << renderer.Render();
-    // TODO(fangjun): check number of sates of "connected"
-    // and check its arcs.
-    //
-    // Check arc_map
+    std::vector<int32_t> arc_map(10);  // an arbitrary number
+    Connect(fsa, &connected, &arc_map);
+
+    EXPECT_EQ(connected.NumStates(), 4u);  // state 3,4,5 from fsa are removed
+    EXPECT_EQ(connected.arc_indexes[0], 0);
+    EXPECT_EQ(connected.arc_indexes[1], 2);
+    EXPECT_EQ(connected.arc_indexes[2], 3);
+    EXPECT_EQ(connected.arc_indexes[3], 4);
+
+    EXPECT_EQ(connected.arcs[0].src_state, 0);
+    EXPECT_EQ(connected.arcs[0].dest_state, 1);
+    EXPECT_EQ(connected.arcs[0].label, 1);
+
+    EXPECT_EQ(connected.arcs[1].src_state, 0);
+    EXPECT_EQ(connected.arcs[1].dest_state, 2);
+    EXPECT_EQ(connected.arcs[1].label, 2);
+
+    EXPECT_EQ(connected.arcs[2].src_state, 1);
+    EXPECT_EQ(connected.arcs[2].dest_state, 3);
+    EXPECT_EQ(connected.arcs[2].label, 6);
+
+    EXPECT_EQ(connected.arcs[3].src_state, 2);
+    EXPECT_EQ(connected.arcs[3].dest_state, 3);
+    EXPECT_EQ(connected.arcs[3].label, 3);
+
+    EXPECT_EQ(arc_map.size(), 4u);
+    EXPECT_EQ(arc_map[0], 0);  // arc index 0 of original state 0 -> 1
+    EXPECT_EQ(arc_map[1], 1);  // arc index 1 of original state 0 -> 2
+    EXPECT_EQ(arc_map[2], 3);  // arc index 3 of original state 1 -> 6
+    EXPECT_EQ(arc_map[3], 5);  // arc index 5 of original state 2 -> 6
   }
 }
 

--- a/k2/csrc/fsa_algo_test.cc
+++ b/k2/csrc/fsa_algo_test.cc
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace k2 {
@@ -36,21 +37,15 @@ TEST(FsaAlgo, Connect) {
     std::vector<int32_t> state_map(10);  // an arbitrary number
     ConnectCore(fsa, &state_map);
 
-    EXPECT_EQ(state_map.size(), 4u);
-    EXPECT_EQ(state_map[0], 0);
-    EXPECT_EQ(state_map[1], 1);
-    EXPECT_EQ(state_map[2], 2);
-    EXPECT_EQ(state_map[3], 6);
+    ASSERT_EQ(state_map.size(), 4u);
+    EXPECT_THAT(state_map, ::testing::ElementsAre(0, 1, 2, 6));
 
     Fsa connected;
     std::vector<int32_t> arc_map(10);  // an arbitrary number
     Connect(fsa, &connected, &arc_map);
 
-    EXPECT_EQ(connected.NumStates(), 4u);  // state 3,4,5 from fsa are removed
-    EXPECT_EQ(connected.arc_indexes[0], 0);
-    EXPECT_EQ(connected.arc_indexes[1], 2);
-    EXPECT_EQ(connected.arc_indexes[2], 3);
-    EXPECT_EQ(connected.arc_indexes[3], 4);
+    ASSERT_EQ(connected.NumStates(), 4u);  // state 3,4,5 from fsa are removed
+    EXPECT_THAT(connected.arc_indexes, ::testing::ElementsAre(0, 2, 3, 4));
 
     EXPECT_EQ(connected.arcs[0].src_state, 0);
     EXPECT_EQ(connected.arcs[0].dest_state, 1);
@@ -68,11 +63,37 @@ TEST(FsaAlgo, Connect) {
     EXPECT_EQ(connected.arcs[3].dest_state, 3);
     EXPECT_EQ(connected.arcs[3].label, 3);
 
-    EXPECT_EQ(arc_map.size(), 4u);
-    EXPECT_EQ(arc_map[0], 0);  // arc index 0 of original state 0 -> 1
-    EXPECT_EQ(arc_map[1], 1);  // arc index 1 of original state 0 -> 2
-    EXPECT_EQ(arc_map[2], 3);  // arc index 3 of original state 1 -> 6
-    EXPECT_EQ(arc_map[3], 5);  // arc index 5 of original state 2 -> 6
+    ASSERT_EQ(arc_map.size(), 4u);
+
+    // arc index 0 of original state 0 -> 1
+    // arc index 1 of original state 0 -> 2
+    // arc index 3 of original state 1 -> 6
+    // arc index 5 of original state 2 -> 6
+    EXPECT_THAT(arc_map, ::testing::ElementsAre(0, 1, 3, 5));
+  }
+
+  {
+    // A non-empty fsa that after trimming, it returns an empty fsa.
+    std::vector<Arc> arcs = {
+        {0, 1, 1}, {0, 2, 2}, {1, 3, 3}, {1, 6, 6},
+        {2, 4, 2}, {2, 6, 3}, {5, 0, 1}, {5, 7, 2},
+    };
+
+    std::vector<int32_t> arc_indexes = {0, 2, 4, 6, 6, 6, 8, 8};
+
+    Fsa fsa;
+    fsa.arc_indexes = std::move(arc_indexes);
+    fsa.arcs = std::move(arcs);
+
+    std::vector<int32_t> state_map(10);  // an arbitrary number
+    ConnectCore(fsa, &state_map);
+    EXPECT_TRUE(state_map.empty());
+
+    Fsa connected;
+    std::vector<int32_t> arc_map(10);  // an arbitrary number
+    Connect(fsa, &connected, &arc_map);
+    EXPECT_TRUE(IsEmpty(connected));
+    EXPECT_TRUE(arc_map.empty());
   }
 }
 

--- a/k2/csrc/fsa_util.cc
+++ b/k2/csrc/fsa_util.cc
@@ -15,7 +15,7 @@ void GetEnteringArcs(const Fsa &fsa, std::vector<int32_t> *arc_index,
                      std::vector<int32_t> *end_index) {
   // CHECK(CheckProperties(fsa, KTopSorted));
 
-  int32_t num_states = fsa.NumStates();
+  auto num_states = fsa.NumStates();
   std::vector<std::vector<int32_t>> vec(num_states);
   int32_t k = 0;
   for (const auto &arc : fsa.arcs) {
@@ -26,8 +26,7 @@ void GetEnteringArcs(const Fsa &fsa, std::vector<int32_t> *arc_index,
   arc_index->clear();
   end_index->clear();
 
-  std::size_t num_arcs = fsa.arcs.size();
-  arc_index->reserve(num_arcs);
+  arc_index->reserve(fsa.arcs.size());
   end_index->reserve(num_states);
 
   for (const auto &indices : vec) {

--- a/k2/csrc/fsa_util.cc
+++ b/k2/csrc/fsa_util.cc
@@ -13,8 +13,6 @@ namespace k2 {
 
 void GetEnteringArcs(const Fsa &fsa, std::vector<int32_t> *arc_index,
                      std::vector<int32_t> *end_index) {
-  // CHECK(CheckProperties(fsa, KTopSorted));
-
   auto num_states = fsa.NumStates();
   std::vector<std::vector<int32_t>> vec(num_states);
   int32_t k = 0;

--- a/k2/csrc/weights.h
+++ b/k2/csrc/weights.h
@@ -4,14 +4,14 @@
 
 // See ../../LICENSE for clarification regarding multiple authors
 
+#ifndef K2_CSRC_WEIGHTS_H_
+#define K2_CSRC_WEIGHTS_H_
+
 #include <vector>
 
 #include "k2/csrc/fsa.h"
-#include "k2/csrc/fsa_properties.h"
 #include "k2/csrc/fsa_util.h"
-
-#ifndef K2_CSRC_WEIGHTS_H_
-#define K2_CSRC_WEIGHTS_H_
+#include "k2/csrc/properties.h"
 
 namespace k2 {
 
@@ -30,7 +30,7 @@ namespace k2 {
   It's like shortest path but with the opposite sign.
 
    @param [in] fsa  The fsa we are doing the forward computation on.
-                Must satisfy IsValid(fsa) and IsTopSorted(fsa).
+                    Must satisfy IsValid(fsa) and IsTopSorted(fsa).
    @param [out] state_weights  The per-state weights will be written to here.
                 They will be 0 for the start-state (if fsa is
                 nonempty), and for later states will be the
@@ -56,7 +56,7 @@ void ComputeForwardMaxWeights(const Fsa &fsa, float *state_weights);
  */
 void ComputeBackwardMaxWeights(const Fsa &fsa, float *state_weights);
 
-enum { kMaxWeight, kLogSumWeight } FbWeightType;
+enum FbWeightType { kMaxWeight, kLogSumWeight };
 
 struct WfsaWithFbWeights {
   const Fsa *fsa;


### PR DESCRIPTION
Only `arc_map` is missing.

For the following fsa,

![trim](https://user-images.githubusercontent.com/5284924/80284508-7bf55d80-8751-11ea-86ac-c7101e3cbd23.png)

the algorithm prints:

```
state 5 is not accessible
state 3 is not coaccessible
state 4 is not coaccessible
state 5 is not coaccessible
```

The implementation is inspired by OpenFST. Only a single forward pass is enough.
No backward pass is performed.

----

State 5 is considered as not coaccessible because the current implementation assumes
that every path has to start with the initial state 0. @danpovey , if you think
this is not suitable, I can change the implementation.

----

It does NOT require a topo-sorted input fsa.