### PR TITLE
fix ConnectCore.

### DIFF
--- a/k2/csrc/fsa_algo.cc
+++ b/k2/csrc/fsa_algo.cc
@@ -8,6 +8,7 @@
 #include "k2/csrc/fsa_algo.h"
 
 #include <algorithm>
+#include <limits>
 #include <numeric>
 #include <queue>
 #include <stack>

--- a/k2/csrc/fsa_algo.h
+++ b/k2/csrc/fsa_algo.h
@@ -27,8 +27,11 @@ namespace k2 {
                               state indexes in `fsa`. If the input fsa is
                               acyclic, the output fsa is topologically sorted.
 
-     @return true if the output fsa is topsorted, or is empty;
-             false otherwise.
+      Returns true on success (i.e. the output will be topsorted).
+      The only failure condition is when the input had cycles that were not self loops.
+
+      Caution: true return status does not imply that the returned FSA is nonempty.
+
  */
 bool ConnectCore(const Fsa &fsa, std::vector<int32_t> *state_map);
 
@@ -50,8 +53,10 @@ bool ConnectCore(const Fsa &fsa, std::vector<int32_t> *state_map);
                             output a map from the arc-index in `b` to
                             the corresponding arc-index in `a`.
 
-     @return true if the output fsa is topsorted, or is empty.
-             false otherwise.
+      Returns true on success (i.e. the output is topsorted).
+      The only failure condition is when the input had cycles that were not self loops.
+
+      Caution: true return status does not imply that the returned FSA is nonempty.
 
   Notes:
     - If `a` admitted a topological sorting, b will be topologically

--- a/k2/csrc/fsa_algo.h
+++ b/k2/csrc/fsa_algo.h
@@ -19,23 +19,28 @@ namespace k2 {
   or are not coaccessible, i.e. not reachable from start state or cannot reach
   the final state.
 
-  If the resulting Fsa is empty, `state_map` will be empty at exit.
+  If the resulting Fsa is empty, `state_map` will be empty at exit and
+  it returns true.
 
      @param [in]  fsa         The FSA to be connected.  Requires
      @param [out] state_map   Maps from state indexes in the output fsa to
                               state indexes in `fsa`. If the input fsa is
                               acyclic, the output fsa is topologically sorted.
+
+     @return true if the output fsa is topsorted, or is empty;
+             false otherwise.
  */
-void ConnectCore(const Fsa &fsa, std::vector<int32_t> *state_map);
+bool ConnectCore(const Fsa &fsa, std::vector<int32_t> *state_map);
 
 /*
   Removes states that are not accessible (from the start state) or are not
-  co-accessible (i.e. that cannot reach the final state), and ensures that if the
-  FSA admits a topological sorting (i.e. if contains no cycles except
-  self-loops), the version that is output is topologically sorted.
+  co-accessible (i.e. that cannot reach the final state), and ensures that
+  if the FSA admits a topological sorting (i.e. it contains no cycles except
+  self-loops), the version that is output is topologically sorted (states may
+  be renumbered).
 
-  If the input fsa is not topologically sorted but is acyclic, then the output
-  fsa is topologically sorted.
+  Whenever the output fsa is acyclic or contains only self-loops, it is
+  topsorted.
 
      @param [in] a    Input FSA
      @param [out] b   Output FSA, that will be trim / connected (there are
@@ -45,18 +50,21 @@ void ConnectCore(const Fsa &fsa, std::vector<int32_t> *state_map);
                             output a map from the arc-index in `b` to
                             the corresponding arc-index in `a`.
 
+     @return true if the output fsa is topsorted, or is empty.
+             false otherwise.
+
   Notes:
     - If `a` admitted a topological sorting, b will be topologically
       sorted. If `a` is not topologically sorted but is acyclic, b will
       also be topologically sorted. TODO(Dan): maybe just leave in the
-      same order as a??
+      same order as a?? (Current implementation may **renumber** the state)
     - If `a` was deterministic, `b` will be deterministic; same for
       epsilon free, obviously.
     - `b` will be arc-sorted (arcs sorted by label). TODO(fangjun): this
        has not be implemented.
     - `b` will (obviously) be connected
  */
-void Connect(const Fsa &a, Fsa *b, std::vector<int32_t> *arc_map = nullptr);
+bool Connect(const Fsa &a, Fsa *b, std::vector<int32_t> *arc_map = nullptr);
 
 /**
    Output an Fsa that is equivalent to the input (in the tropical semiring,

--- a/k2/csrc/fsa_algo.h
+++ b/k2/csrc/fsa_algo.h
@@ -21,34 +21,39 @@ namespace k2 {
 
   If the resulting Fsa is empty, `state_map` will be empty at exit.
 
-     @param [in] fsa  The FSA to be connected.  Requires
+     @param [in]  fsa         The FSA to be connected.  Requires
      @param [out] state_map   Maps from state indexes in the output fsa to
-                      state indexes in `fsa`.  Will retain the original order,
-                      so the output will be topologically sorted if the input
-                      was.
+                              state indexes in `fsa`. If the input fsa is
+                              acyclic, the output fsa is topologically sorted.
  */
 void ConnectCore(const Fsa &fsa, std::vector<int32_t> *state_map);
 
 /*
   Removes states that are not accessible (from the start state) or are not
-  coaccessible (i.e. that cannot reach the final state), and ensures that if the
+  co-accessible (i.e. that cannot reach the final state), and ensures that if the
   FSA admits a topological sorting (i.e. if contains no cycles except
   self-loops), the version that is output is topologically sorted.
 
+  If the input fsa is not topologically sorted but is acyclic, then the output
+  fsa is topologically sorted.
+
      @param [in] a    Input FSA
      @param [out] b   Output FSA, that will be trim / connected (there are
-                     two terminologies).
+                      two terminologies).
 
      @param [out] arc_map   If non-NULL, this function will
-                     output a map from the arc-index in `b` to
-                     the corresponding arc-index in `a`.
+                            output a map from the arc-index in `b` to
+                            the corresponding arc-index in `a`.
 
   Notes:
     - If `a` admitted a topological sorting, b will be topologically
-      sorted.  TODO(Dan): maybe just leave in the same order as a??
+      sorted. If `a` is not topologically sorted but is acyclic, b will
+      also be topologically sorted. TODO(Dan): maybe just leave in the
+      same order as a??
     - If `a` was deterministic, `b` will be deterministic; same for
       epsilon free, obviously.
-    - `b` will be arc-sorted (arcs sorted by label)
+    - `b` will be arc-sorted (arcs sorted by label). TODO(fangjun): this
+       has not be implemented.
     - `b` will (obviously) be connected
  */
 void Connect(const Fsa &a, Fsa *b, std::vector<int32_t> *arc_map = nullptr);

--- a/k2/csrc/fsa_util.cc
+++ b/k2/csrc/fsa_util.cc
@@ -138,10 +138,11 @@ std::unique_ptr<Fsa> StringToFsa(const std::string &s) {
   bool finished = false;  // when the final state is read, set it to true.
   int32_t num_arcs = 0;
   while (std::getline(is, line)) {
-    CHECK_EQ(finished, false);
     std::vector<std::string> splits;
     SplitStringToVector(line, kDelim, &splits);
     if (splits.empty()) continue;
+
+    CHECK_EQ(finished, false);
 
     auto fields = StringVectorToIntVector(splits);
     auto num_fields = fields.size();


### PR DESCRIPTION
Return a topologically sorted fsa if the input fsa is acyclic.

The state map is not necessarily an identity map if the input fsa
is topo sorted, i.e., states may be renumbered.


----

Example:

Input fsa:
![example-1-input](https://user-images.githubusercontent.com/5284924/80912627-d5bcdf80-8d70-11ea-8455-370097c404aa.png)

Output fsa:
![example-1-output](https://user-images.githubusercontent.com/5284924/80912634-e3726500-8d70-11ea-8af9-09ab841e40a9.png)
