### PR TITLE
Create arc_indexes from arcs, add a duplicate of final state

### DIFF
--- a/k2/csrc/CMakeLists.txt
+++ b/k2/csrc/CMakeLists.txt
@@ -22,6 +22,7 @@ function(k2_add_fsa_test name)
   target_link_libraries(${name}
     PRIVATE
       fsa
+      glog
       gtest
       gtest_main
   )

--- a/k2/csrc/fsa.h
+++ b/k2/csrc/fsa.h
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "glog/logging.h"
 #include "k2/csrc/util.h"
 
 namespace k2 {
@@ -66,7 +67,8 @@ struct ArcHash {
 /*
   struct Fsa is an unweighted finite-state acceptor (FSA) and is at the core of
   operations on weighted FSA's and finite state transducers (FSTs).  Note: being
-  a final-state is represented by an arc with label == kEpsilon to final_state.
+  a final-state is represented by an arc with label == kFinalSymbol to
+  final_state.
 
   The start-state is always numbered zero and the final-state is always the
   last-numbered state.  However, we represent the empty FSA (the one that
@@ -77,13 +79,43 @@ struct Fsa {
   // contains the first arc-index leaving this state (index into `arcs`).
   // The next element of this array gives the end of that range.
   // Note: the final-state is numbered last, and implicitly has no
-  // arcs leaving it.
+  // arcs leaving it. For non-empty FSA, we put a duplicate of the final state
+  // at the end of `arc_indexes` to avoid boundary check for some FSA
+  // operations. Caution: users should never call `arc_indexes.size()` to get
+  // the number of states, they should call `NumStates()` to get the number.
   std::vector<int32_t> arc_indexes;
 
   // Note: an index into the `arcs` array is called an arc-index.
   std::vector<Arc> arcs;
 
-  StateId NumStates() const { return static_cast<StateId>(arc_indexes.size()); }
+  Fsa() = default;
+  // just for creating testing FSA examples for now.
+  Fsa(std::vector<Arc> fsa_arcs, int32_t final_state)
+      : arcs(std::move(fsa_arcs)) {
+    if (arcs.empty()) return;
+
+    int32_t curr_state = -1;
+    int32_t index = 0;
+    for (const auto &arc : arcs) {
+      CHECK_LE(arc.src_state, final_state);
+      CHECK_LE(arc.dest_state, final_state);
+      CHECK_LE(curr_state, arc.src_state);
+      while (curr_state < arc.src_state) {
+        arc_indexes.push_back(index);
+        ++curr_state;
+      }
+      ++index;
+    }
+    // noted that here we push two `final_state` at the end, the last element is
+    // just to avoid boundary check for some FSA operations.
+    for (; curr_state <= final_state; ++curr_state)
+      arc_indexes.push_back(index);
+  }
+
+  StateId NumStates() const {
+    return !arc_indexes.empty() ? (static_cast<StateId>(arc_indexes.size()) - 1)
+                                : 0;
+  }
 };
 
 /*

--- a/k2/csrc/fsa_equivalent.cc
+++ b/k2/csrc/fsa_equivalent.cc
@@ -74,6 +74,7 @@ bool RandomPath(const Fsa &a, Fsa *b,
   if (state_map != nullptr) {
     state_map->swap(state_map_b2a);
   }
+  b->arc_indexes.emplace_back(b->arc_indexes.back());
   return true;
 }
 

--- a/k2/csrc/fsa_equivalent_test.cc
+++ b/k2/csrc/fsa_equivalent_test.cc
@@ -28,14 +28,14 @@ TEST(Properties, RandomPathFail) {
 
 TEST(FsaEquivalent, RandomPathSuccess) {
   {
-    Fsa fsa;
-    std::vector<Arc> arcs = {
-        {0, 1, 1}, {0, 2, 2}, {1, 2, 3}, {2, 3, 4},
-        {2, 4, 5}, {3, 4, 7}, {4, 5, 9},
-    };
-    std::vector<int32_t> arc_indexes = {0, 2, 3, 5, 6, 7};
-    fsa.arc_indexes = std::move(arc_indexes);
-    fsa.arcs = std::move(arcs);
+    std::vector<Arc> arcs = {{0, 1, 1},
+                             {0, 2, 2},
+                             {1, 2, 3},
+                             {2, 3, 4},
+                             {2, 4, 5},
+                             {3, 4, 7},
+                             {4, 5, 9}, };
+    Fsa fsa(std::move(arcs), 5);
     Fsa path;
 
     {
@@ -55,15 +55,8 @@ TEST(FsaEquivalent, RandomPathSuccess) {
 
   // test with linear structure fsa to check the resulted path
   {
-    Fsa fsa;
-    std::vector<Arc> arcs = {
-        {0, 1, 1},
-        {1, 2, 3},
-        {2, 3, 4},
-    };
-    std::vector<int32_t> arc_indexes = {0, 1, 2, 3};
-    fsa.arc_indexes = std::move(arc_indexes);
-    fsa.arcs = std::move(arcs);
+    std::vector<Arc> arcs = {{0, 1, 1}, {1, 2, 3}, {2, 3, 4}, };
+    Fsa fsa(std::move(arcs), 3);
     Fsa path;
 
     std::vector<int32_t> state_map;
@@ -77,10 +70,15 @@ TEST(FsaEquivalent, RandomPathSuccess) {
   }
 
   // TODO(haowen): add tests for non-connected fsa
-  std::vector<Arc> arcs = {
-      {0, 1, 1}, {0, 2, 2}, {1, 2, 3}, {2, 3, 4}, {2, 4, 5},
-      {3, 1, 6}, {3, 4, 7}, {4, 3, 8}, {4, 5, 9},
-  };
+  std::vector<Arc> arcs = {{0, 1, 1},
+                           {0, 2, 2},
+                           {1, 2, 3},
+                           {2, 3, 4},
+                           {2, 4, 5},
+                           {3, 1, 6},
+                           {3, 4, 7},
+                           {4, 3, 8},
+                           {4, 5, 9}, };
   std::vector<int32_t> arc_indexes = {0, 2, 3, 5, 7, 9};
 }
 }  // namespace k2

--- a/k2/csrc/fsa_renderer_test.cc
+++ b/k2/csrc/fsa_renderer_test.cc
@@ -25,13 +25,9 @@ namespace k2 {
 // as expected.
 TEST(FsaRenderer, Render) {
   std::vector<Arc> arcs = {
-      {0, 1, 2}, {0, 2, 1}, {1, 2, 0}, {1, 3, 5}, {2, 3, 6},
-  };
-  std::vector<int32_t> arc_indexes = {0, 2, 4, 5};
+      {0, 1, 2}, {0, 2, 1}, {1, 2, 0}, {1, 3, 5}, {2, 3, 6}, };
 
-  Fsa fsa;
-  fsa.arc_indexes = std::move(arc_indexes);
-  fsa.arcs = std::move(arcs);
+  Fsa fsa(std::move(arcs), 3);
 
   FsaRenderer renderer(fsa);
   std::cerr << renderer.Render();

--- a/k2/csrc/fsa_util.cc
+++ b/k2/csrc/fsa_util.cc
@@ -177,6 +177,7 @@ std::unique_ptr<Fsa> StringToFsa(const std::string &s) {
     fsa->arcs.insert(fsa->arcs.end(), v.begin(), v.end());
     ++i;
   }
+  fsa->arc_indexes.emplace_back(fsa->arc_indexes.back());
   return fsa;
 }
 

--- a/k2/csrc/fsa_util_test.cc
+++ b/k2/csrc/fsa_util_test.cc
@@ -65,13 +65,16 @@ TEST(FsaUtil, StringToFsa) {
   const auto &arc_indexes = fsa->arc_indexes;
   const auto &arcs = fsa->arcs;
 
-  ASSERT_EQ(arc_indexes.size(), 7u);
-  EXPECT_THAT(arc_indexes, ::testing::ElementsAre(0, 2, 4, 6, 6, 6, 7));
+  ASSERT_EQ(arc_indexes.size(), 8u);
+  EXPECT_THAT(arc_indexes, ::testing::ElementsAre(0, 2, 4, 6, 6, 6, 7, 7));
 
-  std::vector<Arc> expected_arcs = {
-      {0, 1, 2}, {0, 2, 10}, {1, 3, 3}, {1, 6, 6},
-      {2, 6, 1}, {2, 4, 2},  {5, 0, 1},
-  };
+  std::vector<Arc> expected_arcs = {{0, 1, 2},
+                                    {0, 2, 10},
+                                    {1, 3, 3},
+                                    {1, 6, 6},
+                                    {2, 6, 1},
+                                    {2, 4, 2},
+                                    {5, 0, 1}, };
 
   auto n = static_cast<int32_t>(expected_arcs.size());
   for (auto i = 0; i != n; ++i) {

--- a/k2/csrc/properties_test.cc
+++ b/k2/csrc/properties_test.cc
@@ -30,73 +30,40 @@ TEST(Properties, IsNotValid) {
 
   // only kFinalSymbol arcs enter the final state
   {
-    Fsa fsa;
-    std::vector<Arc> arcs = {
-        {0, 1, 0},
-        {0, 2, 1},
-        {1, 2, 0},
-    };
-    std::vector<int32_t> arc_indexes = {0, 2, 3};
-    fsa.arc_indexes = std::move(arc_indexes);
-    fsa.arcs = std::move(arcs);
+    std::vector<Arc> arcs = {{0, 1, 0}, {0, 2, 1}, {1, 2, 0}, };
+    Fsa fsa(std::move(arcs), 2);
     bool is_valid = IsValid(fsa);
     EXPECT_FALSE(is_valid);
   }
 
   // every state contains at least one arc except the final state
   {
-    Fsa fsa;
-    std::vector<Arc> arcs = {
-        {0, 1, 0},
-        {0, 2, 0},
-        {2, 3, 0},
-    };
-    std::vector<int32_t> arc_indexes = {0, 2, 2, 3};
-    fsa.arc_indexes = std::move(arc_indexes);
-    fsa.arcs = std::move(arcs);
+    std::vector<Arc> arcs = {{0, 1, 0}, {0, 2, 0}, {2, 3, 0}, };
+    Fsa fsa(std::move(arcs), 3);
     bool is_valid = IsValid(fsa);
     EXPECT_FALSE(is_valid);
   }
 
   // every state contains at least one arc except the final state (another case)
   {
-    Fsa fsa;
-    std::vector<Arc> arcs = {
-        {0, 1, 0},
-        {0, 2, 0},
-    };
-    std::vector<int32_t> arc_indexes = {0, 2, 2};
-    fsa.arc_indexes = std::move(arc_indexes);
-    fsa.arcs = std::move(arcs);
+    std::vector<Arc> arcs = {{0, 1, 0}, {0, 2, 0}, };
+    Fsa fsa(std::move(arcs), 2);
     bool is_valid = IsValid(fsa);
     EXPECT_FALSE(is_valid);
   }
 
   // `arc_indexes` and `arcs` in this state are not consistent
   {
-    Fsa fsa;
-    std::vector<Arc> arcs = {
-        {0, 1, 0},
-        {0, 2, 0},
-    };
-    std::vector<int32_t> arc_indexes = {0, 2, 3, 3};
-    fsa.arc_indexes = std::move(arc_indexes);
-    fsa.arcs = std::move(arcs);
+    std::vector<Arc> arcs = {{0, 1, 0}, {0, 2, 0}, };
+    Fsa fsa(std::move(arcs), 3);
     bool is_valid = IsValid(fsa);
     EXPECT_FALSE(is_valid);
   }
 
   // `arc_indexes` and `arcs` in this state are not consistent (another case)
   {
-    Fsa fsa;
-    std::vector<Arc> arcs = {
-        {0, 1, 0},
-        {0, 2, 0},
-        {1, 2, 0},
-    };
-    std::vector<int32_t> arc_indexes = {0, 2, 4};
-    fsa.arc_indexes = std::move(arc_indexes);
-    fsa.arcs = std::move(arcs);
+    std::vector<Arc> arcs = {{0, 1, 0}, {0, 2, 0}, {1, 2, 0}, };
+    Fsa fsa(std::move(arcs), 2);
     bool is_valid = IsValid(fsa);
     EXPECT_FALSE(is_valid);
   }
@@ -112,73 +79,39 @@ TEST(Properties, IsValid) {
 
   {
     std::vector<Arc> arcs = {
-        {0, 1, 0},
-        {0, 2, kFinalSymbol},
-        {1, 2, kFinalSymbol},
-    };
-    std::vector<int32_t> arc_indexes = {0, 2, 3};
-    Fsa fsa;
-    fsa.arc_indexes = std::move(arc_indexes);
-    fsa.arcs = std::move(arcs);
+        {0, 1, 0}, {0, 2, kFinalSymbol}, {1, 2, kFinalSymbol}, };
+    Fsa fsa(std::move(arcs), 2);
     bool is_valid = IsValid(fsa);
     EXPECT_TRUE(is_valid);
   }
 }
 
 TEST(Properties, IsNotTopSorted) {
-  std::vector<Arc> arcs = {
-      {0, 1, 0},
-      {0, 2, 0},
-      {2, 1, 0},
-  };
-  std::vector<int32_t> arc_indexes = {0, 2, 3};
-  Fsa fsa;
-  fsa.arc_indexes = std::move(arc_indexes);
-  fsa.arcs = std::move(arcs);
+  std::vector<Arc> arcs = {{0, 1, 0}, {0, 2, 0}, {2, 1, 0}, };
+  Fsa fsa(std::move(arcs), 2);
   bool sorted = IsTopSorted(fsa);
   EXPECT_FALSE(sorted);
 }
 
 TEST(Properties, IsTopSorted) {
-  std::vector<Arc> arcs = {
-      {0, 1, 0},
-      {0, 2, 0},
-      {1, 2, 0},
-  };
-  std::vector<int32_t> arc_indexes = {0, 2, 3};
-  Fsa fsa;
-  fsa.arc_indexes = std::move(arc_indexes);
-  fsa.arcs = std::move(arcs);
+  std::vector<Arc> arcs = {{0, 1, 0}, {0, 2, 0}, {1, 2, 0}, };
+  Fsa fsa(std::move(arcs), 2);
   bool sorted = IsTopSorted(fsa);
   EXPECT_TRUE(sorted);
 }
 
 TEST(Properties, IsNotArcSorted) {
   {
-    std::vector<Arc> arcs = {
-        {0, 1, 1},
-        {0, 2, 2},
-        {1, 2, 2},
-        {1, 3, 1},
-    };
-    std::vector<int32_t> arc_indexes = {0, 2, 4, 4};
-    Fsa fsa;
-    fsa.arc_indexes = std::move(arc_indexes);
-    fsa.arcs = std::move(arcs);
+    std::vector<Arc> arcs = {{0, 1, 1}, {0, 2, 2}, {1, 2, 2}, {1, 3, 1}, };
+    Fsa fsa(std::move(arcs), 3);
     bool sorted = IsArcSorted(fsa);
     EXPECT_FALSE(sorted);
   }
 
   // another case with same label on two arcs
   {
-    std::vector<Arc> arcs = {
-        {0, 2, 0},
-        {0, 1, 0},
-    };
-    std::vector<int32_t> arc_indexes = {0, 2, 2};
-    Fsa fsa;
-    fsa.arc_indexes = std::move(arc_indexes);
-    fsa.arcs = std::move(arcs);
+    std::vector<Arc> arcs = {{0, 2, 0}, {0, 1, 0}, };
+    Fsa fsa(std::move(arcs), 2);
     bool sorted = IsArcSorted(fsa);
     EXPECT_FALSE(sorted);
   }
@@ -193,101 +126,51 @@ TEST(Properties, IsArcSorted) {
   }
 
   {
-    std::vector<Arc> arcs = {
-        {0, 1, 0},
-        {0, 2, 0},
-        {1, 2, 1},
-        {1, 3, 2},
-    };
-    std::vector<int32_t> arc_indexes = {0, 2, 4, 4};
-    Fsa fsa;
-    fsa.arc_indexes = std::move(arc_indexes);
-    fsa.arcs = std::move(arcs);
+    std::vector<Arc> arcs = {{0, 1, 0}, {0, 2, 0}, {1, 2, 1}, {1, 3, 2}, };
+    Fsa fsa(std::move(arcs), 3);
     bool sorted = IsArcSorted(fsa);
     EXPECT_TRUE(sorted);
   }
 }
 
 TEST(Properties, HasNoSelfLoops) {
-  std::vector<Arc> arcs = {
-      {0, 1, 0},
-      {0, 2, 0},
-      {1, 2, 0},
-  };
-  std::vector<int32_t> arc_indexes = {0, 2, 3};
-  Fsa fsa;
-  fsa.arc_indexes = std::move(arc_indexes);
-  fsa.arcs = std::move(arcs);
+  std::vector<Arc> arcs = {{0, 1, 0}, {0, 2, 0}, {1, 2, 0}, };
+  Fsa fsa(std::move(arcs), 2);
   bool has_self_loops = HasSelfLoops(fsa);
   EXPECT_FALSE(has_self_loops);
 }
 
 TEST(Properties, HasSelfLoops) {
-  std::vector<Arc> arcs = {
-      {0, 1, 0},
-      {1, 2, 0},
-      {1, 1, 0},
-  };
-  std::vector<int32_t> arc_indexes = {0, 1, 3};
-  Fsa fsa;
-  fsa.arc_indexes = std::move(arc_indexes);
-  fsa.arcs = std::move(arcs);
+  std::vector<Arc> arcs = {{0, 1, 0}, {1, 2, 0}, {1, 1, 0}, };
+  Fsa fsa(std::move(arcs), 2);
   bool has_self_loops = HasSelfLoops(fsa);
   EXPECT_TRUE(has_self_loops);
 }
 
 TEST(Properties, IsNotDeterministic) {
-  std::vector<Arc> arcs = {
-      {0, 1, 2},
-      {1, 2, 0},
-      {1, 3, 0},
-  };
-  std::vector<int32_t> arc_indexes = {0, 1, 3};
-  Fsa fsa;
-  fsa.arc_indexes = std::move(arc_indexes);
-  fsa.arcs = std::move(arcs);
+  std::vector<Arc> arcs = {{0, 1, 2}, {1, 2, 0}, {1, 3, 0}, };
+  Fsa fsa(std::move(arcs), 3);
   bool is_deterministic = IsDeterministic(fsa);
   EXPECT_FALSE(is_deterministic);
 }
 
 TEST(Properties, IsDeterministic) {
-  std::vector<Arc> arcs = {
-      {0, 1, 2},
-      {1, 2, 0},
-      {1, 3, 2},
-  };
-  std::vector<int32_t> arc_indexes = {0, 1, 3};
-  Fsa fsa;
-  fsa.arc_indexes = std::move(arc_indexes);
-  fsa.arcs = std::move(arcs);
+  std::vector<Arc> arcs = {{0, 1, 2}, {1, 2, 0}, {1, 3, 2}, };
+  Fsa fsa(std::move(arcs), 3);
   bool is_deterministic = IsDeterministic(fsa);
   EXPECT_TRUE(is_deterministic);
 }
 
 TEST(Properties, IsNotEpsilonFree) {
-  std::vector<Arc> arcs = {
-      {0, 1, 2},
-      {0, 2, 0},
-      {1, 2, 1},
-  };
-  std::vector<int32_t> arc_indexes = {0, 2, 3};
-  Fsa fsa;
-  fsa.arc_indexes = std::move(arc_indexes);
-  fsa.arcs = std::move(arcs);
+  std::vector<Arc> arcs = {{0, 1, 2}, {0, 2, 0}, {1, 2, 1}, };
+  Fsa fsa(std::move(arcs), 2);
   bool is_epsilon_free = IsEpsilonFree(fsa);
   EXPECT_FALSE(is_epsilon_free);
 }
 
 TEST(Properties, IsEpsilonFree) {
-  std::vector<Arc> arcs = {
-      {0, 1, 2},
-      {0, 2, 1},
-      {1, 2, 1},
-  };
-  std::vector<int32_t> arc_indexes = {0, 2, 3};
-  Fsa fsa;
-  fsa.arc_indexes = std::move(arc_indexes);
-  fsa.arcs = std::move(arcs);
+  std::vector<Arc> arcs = {{0, 1, 2}, {0, 2, 1}, {1, 2, 1}, };
+  Fsa fsa(std::move(arcs), 2);
   bool is_epsilon_free = IsEpsilonFree(fsa);
   EXPECT_TRUE(is_epsilon_free);
 }
@@ -295,27 +178,16 @@ TEST(Properties, IsEpsilonFree) {
 TEST(Properties, IsNoConnected) {
   // state is not accessible
   {
-    std::vector<Arc> arcs = {
-        {0, 2, 0},
-    };
-    std::vector<int32_t> arc_indexes = {0, 1, 1};
-    Fsa fsa;
-    fsa.arc_indexes = std::move(arc_indexes);
-    fsa.arcs = std::move(arcs);
+    std::vector<Arc> arcs = {{0, 2, 0}, };
+    Fsa fsa(std::move(arcs), 2);
     bool is_connected = IsConnected(fsa);
     EXPECT_FALSE(is_connected);
   }
 
   // state is not co-accessible
   {
-    std::vector<Arc> arcs = {
-        {0, 1, 0},
-        {0, 2, 0},
-    };
-    std::vector<int32_t> arc_indexes = {0, 2, 2, 2};
-    Fsa fsa;
-    fsa.arc_indexes = std::move(arc_indexes);
-    fsa.arcs = std::move(arcs);
+    std::vector<Arc> arcs = {{0, 1, 0}, {0, 2, 0}, };
+    Fsa fsa(std::move(arcs), 3);
     bool is_connected = IsConnected(fsa);
     EXPECT_FALSE(is_connected);
   }
@@ -329,16 +201,8 @@ TEST(Properties, IsConnected) {
     EXPECT_TRUE(is_connected);
   }
   {
-    std::vector<Arc> arcs = {
-        {0, 1, 0},
-        {0, 3, 0},
-        {1, 2, 0},
-        {2, 3, 0},
-    };
-    std::vector<int32_t> arc_indexes = {0, 2, 3, 4};
-    Fsa fsa;
-    fsa.arc_indexes = std::move(arc_indexes);
-    fsa.arcs = std::move(arcs);
+    std::vector<Arc> arcs = {{0, 1, 0}, {0, 3, 0}, {1, 2, 0}, {2, 3, 0}, };
+    Fsa fsa(std::move(arcs), 3);
     bool is_connected = IsConnected(fsa);
     EXPECT_TRUE(is_connected);
   }
@@ -346,12 +210,8 @@ TEST(Properties, IsConnected) {
   // another case: fsa is cyclic and not top-sorted
   {
     std::vector<Arc> arcs = {
-        {0, 3, 0}, {1, 2, 0}, {2, 3, 0}, {2, 4, 0}, {3, 1, 0},
-    };
-    std::vector<int32_t> arc_indexes = {0, 1, 2, 4, 5};
-    Fsa fsa;
-    fsa.arc_indexes = std::move(arc_indexes);
-    fsa.arcs = std::move(arcs);
+        {0, 3, 0}, {1, 2, 0}, {2, 3, 0}, {2, 4, 0}, {3, 1, 0}, };
+    Fsa fsa(std::move(arcs), 4);
     bool is_connected = IsConnected(fsa);
     EXPECT_TRUE(is_connected);
   }


### PR DESCRIPTION
- Add a constructor which creating `arc_indexes` from `arcs`.
- Add a duplicate of final state to `arc_indexes` to avoid boundary check in many implentations.

Please merge this PR ASAP before other PRs if there's no other issues as:

- There may be conflicts as I have changed almost all `.cc` files.
- Other algorithm implentation should be based on new structure of `arc_indexes`.