### PR TITLE
rewrite pybind interface for Array2 and Fsa

### DIFF
--- a/k2/python/csrc/CMakeLists.txt
+++ b/k2/python/csrc/CMakeLists.txt
@@ -2,6 +2,7 @@
 pybind11_add_module(_k2
   array.cc
   fsa.cc
+  fsa_algo.cc
   fsa_util.cc
   k2.cc
   tensor.cc

--- a/k2/python/csrc/array.h
+++ b/k2/python/csrc/array.h
@@ -10,5 +10,6 @@
 #include "k2/python/csrc/k2.h"
 
 void PybindArray(py::module &m);
+void PybindArray2Size(py::module &m);
 
 #endif  // K2_PYTHON_CSRC_ARRAY_H_

--- a/k2/python/csrc/fsa_algo.cc
+++ b/k2/python/csrc/fsa_algo.cc
@@ -1,0 +1,42 @@
+// k2/python/csrc/fsa_algo.cc
+
+// Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+
+// See ../../../LICENSE for clarification regarding multiple authors
+
+#include "k2/python/csrc/fsa_algo.h"
+
+#include <memory>
+#include <utility>
+
+#include "k2/csrc/arcsort.h"
+#include "k2/csrc/array.h"
+#include "k2/python/csrc/array.h"
+
+namespace k2 {}  // namespace k2
+
+void PyBindArcSort(py::module &m) {
+  using PyClass = k2::ArcSorter;
+  py::class_<PyClass>(m, "_ArcSorter")
+      .def(py::init<const k2::Fsa &>(), py::arg("fsa_in"))
+      .def("get_sizes", &PyClass::GetSizes, py::arg("fsa_size"))
+      .def(
+          "get_output",
+          [](PyClass &self, k2::Fsa *fsa_out,
+             k2::Array1<int32_t *> *arc_map = nullptr) {
+            self.GetOutput(fsa_out,
+                           arc_map == nullptr ? nullptr : arc_map->data);
+          },
+          py::arg("fsa_out"),
+          py::arg("arc_map") = (k2::Array1<int32_t *> *)nullptr);
+
+  m.def(
+      "_arc_sort",
+      [](k2::Fsa *fsa, k2::Array1<int32_t *> *arc_map = nullptr) {
+        k2::ArcSort(fsa, arc_map == nullptr ? nullptr : arc_map->data);
+      },
+      "in-place version of ArcSorter", py::arg("fsa"),
+      py::arg("arc_map") = (k2::Array1<int32_t *> *)nullptr);
+}
+
+void PybindFsaAlgo(py::module &m) { PyBindArcSort(m); }

--- a/k2/python/csrc/fsa_algo.h
+++ b/k2/python/csrc/fsa_algo.h
@@ -1,0 +1,14 @@
+// k2/python/csrc/fsa_algo.h
+
+// Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+
+// See ../../../LICENSE for clarification regarding multiple authors
+
+#ifndef K2_PYTHON_CSRC_FSA_ALGO_H_
+#define K2_PYTHON_CSRC_FSA_ALGO_H_
+
+#include "k2/python/csrc/k2.h"
+
+void PybindFsaAlgo(py::module &m);
+
+#endif  // K2_PYTHON_CSRC_FSA_ALGO_H_

--- a/k2/python/csrc/k2.cc
+++ b/k2/python/csrc/k2.cc
@@ -8,12 +8,15 @@
 
 #include "k2/python/csrc/array.h"
 #include "k2/python/csrc/fsa.h"
+#include "k2/python/csrc/fsa_algo.h"
 #include "k2/python/csrc/fsa_util.h"
 
 PYBIND11_MODULE(_k2, m) {
   m.doc() = "pybind11 binding of k2";
   PybindArc(m);
   PybindArray(m);
+  PybindArray2Size(m);
   PybindFsa(m);
   PybindFsaUtil(m);
+  PybindFsaAlgo(m);
 }

--- a/k2/python/k2/__init__.py
+++ b/k2/python/k2/__init__.py
@@ -1,4 +1,5 @@
-from _k2 import Arc
+from _k2 import IntArray2Size
 from .array import *
 from .fsa import *
+from .fsa_algo import *
 from .fsa_util import str_to_fsa

--- a/k2/python/k2/array.py
+++ b/k2/python/k2/array.py
@@ -5,17 +5,53 @@
 import torch
 from torch.utils.dlpack import to_dlpack
 
+from _k2 import IntArray2Size
 from _k2 import DLPackIntArray2
+from _k2 import DLPackIntArray1
 from _k2 import DLPackLogSumArcDerivs
+
+
+class IntArray1(DLPackIntArray1):
+
+    def __init__(self, data: torch.Tensor):
+        assert data.dtype == torch.int32
+        self.data = data
+        super().__init__(to_dlpack(self.data))
+
+    @staticmethod
+    def create_array_with_size(size: int):
+        data = torch.zeros(size, dtype=torch.int32)
+        return IntArray1(data)
+
 
 class IntArray2(DLPackIntArray2):
 
-    # TODO(haowen): add methods to construct object with Array2Size
     def __init__(self, indexes: torch.Tensor, data: torch.Tensor):
-        super().__init__(to_dlpack(indexes), to_dlpack(data))
+        assert indexes.dtype == torch.int32
+        assert data.dtype == torch.int32
+        self.indexes = indexes
+        self.data = data
+        super().__init__(to_dlpack(self.indexes), to_dlpack(self.data))
+
+    @staticmethod
+    def create_array_with_size(array_size: IntArray2Size):
+        indexes = torch.zeros(array_size.size1 + 1, dtype=torch.int32)
+        data = torch.zeros(array_size.size2, dtype=torch.int32)
+        return IntArray2(indexes, data)
 
 
 class LogSumArcDerivs(DLPackLogSumArcDerivs):
 
     def __init__(self, indexes: torch.Tensor, data: torch.Tensor):
-        super().__init__(to_dlpack(indexes), to_dlpack(data))
+        assert indexes.dtype == torch.int32
+        assert data.dtype == torch.float32
+        assert data.shape[1] == 2
+        self.indexes = indexes
+        self.data = data
+        super().__init__(to_dlpack(self.indexes), to_dlpack(self.data))
+
+    @staticmethod
+    def create_arc_derivs_with_size(array_size: IntArray2Size):
+        indexes = torch.zeros(array_size.size1 + 1, dtype=torch.int32)
+        data = torch.zeros([array_size.size2, 2], dtype=torch.float32)
+        return LogSumArcDerivs(indexes, data)

--- a/k2/python/k2/fsa.py
+++ b/k2/python/k2/fsa.py
@@ -5,12 +5,49 @@
 import torch
 from torch.utils.dlpack import to_dlpack
 
+from _k2 import IntArray2Size
+from _k2 import _Arc
 from _k2 import DLPackFsa
+from _k2 import IntArray2Size
+
+
+class Arc(_Arc):
+
+    def __init__(self, src_state: int, dest_state: int, label: int):
+        super().__init__(src_state, dest_state, label)
+
+    def to_tensor(self):
+        return torch.tensor([self.src_state, self.dest_state, self.label],
+                            dtype=torch.int32)
+
+    @staticmethod
+    def from_tensor(tensor: torch.Tensor):
+        assert tensor.shape == torch.Size([3])
+        assert tensor.dtype == torch.int32
+        return Arc(*tensor.tolist())
+
 
 class Fsa(DLPackFsa):
+    """
+    Corresponds to k2::Fsa class, initializes k2::Fsa with torch.Tensors.
 
-    # TODO(haowen): add methods to construct object with Array2Size
+    Note that we view each row of self.data as a k2::Arc, usually users 
+    can convert the type between tensor and k2::Arc by calling 
+    `k2.Arc.from_tensor()` and `k2.Arc.to_tensor()`.
+    If users want to change the values in Fsa, just call `fsa.data[i] = some_tensor`.
+    
+    """
+
     def __init__(self, indexes: torch.Tensor, data: torch.Tensor):
-        super().__init__(to_dlpack(indexes), to_dlpack(data))
+        assert indexes.dtype == torch.int32
+        assert data.dtype == torch.int32
+        assert data.shape[1] == 3
+        self.indexes = indexes
+        self.data = data
+        super().__init__(to_dlpack(self.indexes), to_dlpack(self.data))
 
-
+    @staticmethod
+    def create_fsa_with_size(array_size: IntArray2Size):
+        indexes = torch.zeros(array_size.size1 + 1, dtype=torch.int32)
+        data = torch.zeros([array_size.size2, 3], dtype=torch.int32)
+        return Fsa(indexes, data)

--- a/k2/python/k2/fsa_algo.py
+++ b/k2/python/k2/fsa_algo.py
@@ -1,0 +1,30 @@
+# Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+
+# See ../../../LICENSE for clarification regarding multiple authors
+
+import torch
+from torch.utils.dlpack import to_dlpack
+
+from .fsa import Fsa
+from .array import IntArray1
+from .array import IntArray2
+from _k2 import _ArcSorter
+from _k2 import _arc_sort
+
+
+class ArcSorter(_ArcSorter):
+
+    def __init__(self, fsa_in: Fsa):
+        super().__init__(fsa_in.get_base())
+
+    def get_sizes(self, array_size: IntArray2):
+        super().get_sizes(array_size)
+
+    def get_output(self, fsa_out: Fsa, arc_map: IntArray1 = None):
+        super().get_output(fsa_out.get_base(),
+                           arc_map.get_base() if arc_map is not None else None)
+
+
+def arc_sort(fsa: Fsa, arc_map: IntArray1 = None):
+    return _arc_sort(fsa.get_base(),
+                     arc_map.get_base() if arc_map is not None else None)

--- a/k2/python/tests/CMakeLists.txt
+++ b/k2/python/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ endfunction()
 # please sort the files in alphabetic order
 set(py_test_files
     array_test.py
+    fsa_arcsort_test.py
     fsa_test.py
 )
 

--- a/k2/python/tests/array_test.py
+++ b/k2/python/tests/array_test.py
@@ -9,6 +9,7 @@
 #  ctest --verbose -R array_test_py
 #
 
+from struct import pack, unpack
 import unittest
 
 import torch
@@ -18,36 +19,60 @@ import k2
 
 class TestArray(unittest.TestCase):
 
+    def test_int_array1(self):
+        data = torch.arange(10).to(torch.int32)
+
+        array = k2.IntArray1(data)
+        self.assertFalse(array.empty())
+        self.assertIsInstance(array, k2.IntArray1)
+        self.assertEqual(data.numel(), array.size)
+        self.assertEqual(array.data[9], 9)
+
+        # the underlying memory is shared between k2 and torch;
+        # so change one will change another
+        data[0] = 100
+        self.assertEqual(array.data[0], 100)
+        self.assertEqual(array.get_data(0), 100)
+
+        del data
+        # the array in k2 is still accessible
+        self.assertEqual(array.data[0], 100)
+        self.assertEqual(array.get_data(0), 100)
+
     def test_int_array2(self):
         data = torch.arange(10).to(torch.int32)
         indexes = torch.tensor([0, 2, 5, 6, 10]).to(torch.int32)
-        self.assertEqual(data.numel(),indexes[-1].item())
+        self.assertEqual(data.numel(), indexes[-1].item())
 
         array = k2.IntArray2(indexes, data)
         self.assertFalse(array.empty())
         self.assertIsInstance(array, k2.IntArray2)
 
-        # test iterator
-        for i, v in enumerate(array):
-            self.assertEqual(i, v)
-
         self.assertEqual(indexes.numel(), array.size1 + 1)
         self.assertEqual(data.numel(), array.size2)
+        self.assertEqual(array.data[9], 9)
 
         # the underlying memory is shared between k2 and torch;
         # so change one will change another
         data[0] = 100
-        self.assertEqual(array.data(0), 100)
+        self.assertEqual(array.data[0], 100)
+        self.assertEqual(array.get_data(0), 100)
+        indexes[1] = 3
+        self.assertEqual(array.indexes[1], 3)
+        self.assertEqual(array.get_indexes(1), 3)
 
         del data
+        del indexes
         # the array in k2 is still accessible
-        self.assertEqual(array.data(0), 100)
-
+        self.assertEqual(array.data[0], 100)
+        self.assertEqual(array.get_data(0), 100)
+        self.assertEqual(array.indexes[1], 3)
+        self.assertEqual(array.get_indexes(1), 3)
 
     def test_logsum_arc_derivs(self):
-        data = torch.arange(10).reshape(5,2).to(torch.float)
+        data = torch.arange(10).reshape(5, 2).to(torch.float)
         indexes = torch.tensor([0, 2, 3, 5]).to(torch.int32)
-        self.assertEqual(data.shape[0],indexes[-1].item())
+        self.assertEqual(data.shape[0], indexes[-1].item())
 
         array = k2.LogSumArcDerivs(indexes, data)
         self.assertFalse(array.empty())
@@ -55,8 +80,24 @@ class TestArray(unittest.TestCase):
 
         self.assertEqual(indexes.numel(), array.size1 + 1)
         self.assertEqual(data.shape[0], array.size2)
+        self.assertTrue(torch.equal(array.data[0], torch.FloatTensor([0, 1])))
 
-        self.assertEqual(array.data(0), (0,1.0))
+        # the underlying memory is shared between k2 and torch;
+        # so change one will change another
+        data[0] = torch.FloatTensor([100, 200])
+        self.assertTrue(
+            torch.equal(array.data[0], torch.FloatTensor([100, 200])))
+        self.assertEqual(array.get_data(0)[1], 200)
+        # we need pack and then unpack here to interpret arc_id (int) as a float,
+        # this is only for test purpose as users would usually never call
+        # `array.get_data` to retrieve data. Instead, it is supposed to call
+        # `array.data` to retrieve or update data in the array object.
+        arc_id = pack('i', array.get_data(0)[0])
+        self.assertEqual(unpack('f', arc_id)[0], 100)
+
+        del data
+        # the array in k2 is still accessible
+        self.assertEqual(array.get_data(0)[1], 200)
 
 
 if __name__ == '__main__':

--- a/k2/python/tests/fsa_arcsort_test.py
+++ b/k2/python/tests/fsa_arcsort_test.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+#
+# Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+#
+# See ../../../LICENSE for clarification regarding multiple authors
+
+# To run this single test, use
+#
+#  ctest --verbose -R fsa_arcsort_test_py
+#
+
+import unittest
+
+import torch
+
+import k2
+
+
+class TestArcSort(unittest.TestCase):
+
+    def test_empty_fsa(self):
+        array_size = k2.IntArray2Size(0, 0)
+        fsa = k2.Fsa.create_fsa_with_size(array_size)
+        arc_map = k2.IntArray1.create_array_with_size(fsa.size2)
+        k2.arc_sort(fsa, arc_map)
+        self.assertTrue(fsa.empty())
+        self.assertTrue(arc_map.empty())
+
+        # test without arc_map
+        k2.arc_sort(fsa)
+        self.assertTrue(fsa.empty())
+
+    def test_arc_sort(self):
+        s = r'''
+        0 1 2
+        0 4 0
+        0 2 0
+        1 2 1
+        1 3 0
+        2 1 0
+        4
+        '''
+
+        fsa = k2.str_to_fsa(s)
+        arc_map = k2.IntArray1.create_array_with_size(fsa.size2)
+        k2.arc_sort(fsa, arc_map)
+        expected_arc_indexes = torch.IntTensor([0, 3, 5, 6, 6, 6])
+        expected_arcs = torch.IntTensor([[0, 2, 0], [0, 4, 0], [0, 1, 2],
+                                         [1, 3, 0], [1, 2, 1], [2, 1, 0]])
+        expected_arc_map = torch.IntTensor([2, 1, 0, 4, 3, 5])
+        self.assertTrue(torch.equal(fsa.indexes, expected_arc_indexes))
+        self.assertTrue(torch.equal(fsa.data, expected_arcs))
+        self.assertTrue(torch.equal(arc_map.data, expected_arc_map))
+
+
+class TestArcSorter(unittest.TestCase):
+
+    def test_empty_fsa(self):
+        array_size = k2.IntArray2Size(0, 0)
+        fsa = k2.Fsa.create_fsa_with_size(array_size)
+        sorter = k2.ArcSorter(fsa)
+        array_size = k2.IntArray2Size()
+        sorter.get_sizes(array_size)
+        fsa_out = k2.Fsa.create_fsa_with_size(array_size)
+        arc_map = k2.IntArray1.create_array_with_size(fsa.size2)
+        sorter.get_output(fsa_out, arc_map)
+        self.assertTrue(fsa.empty())
+        self.assertTrue(arc_map.empty())
+
+        # test without arc_map
+        sorter.get_output(fsa_out)
+        self.assertTrue(fsa.empty())
+
+    def test_arc_sort(self):
+        s = r'''
+        0 1 2
+        0 4 0
+        0 2 0
+        1 2 1
+        1 3 0
+        2 1 0
+        4
+        '''
+
+        fsa = k2.str_to_fsa(s)
+        sorter = k2.ArcSorter(fsa)
+        array_size = k2.IntArray2Size()
+        sorter.get_sizes(array_size)
+        fsa_out = k2.Fsa.create_fsa_with_size(array_size)
+        arc_map = k2.IntArray1.create_array_with_size(fsa.size2)
+        sorter.get_output(fsa_out, arc_map)
+        expected_arc_indexes = torch.IntTensor([0, 3, 5, 6, 6, 6])
+        expected_arcs = torch.IntTensor([[0, 2, 0], [0, 4, 0], [0, 1, 2],
+                                         [1, 3, 0], [1, 2, 1], [2, 1, 0]])
+        expected_arc_map = torch.IntTensor([2, 1, 0, 4, 3, 5])
+        self.assertTrue(torch.equal(fsa_out.indexes, expected_arc_indexes))
+        self.assertTrue(torch.equal(fsa_out.data, expected_arcs))
+        self.assertTrue(torch.equal(arc_map.data, expected_arc_map))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Guys, please have a review. This PR is relatively **important**, if the whole structure/style is fine, I will follow it to wrap other algorithms to python (most of them will be straightforward).

Note as in Python, we cannot pass primitive type (int, float, etc.) to function as reference/pointer, I get `Array1` back to support those `arc_map` (see example in `arc_sort`)