### PR TITLE
A compile error of k2/k2/csrc/cuda/ops_test.cu #96

### DIFF
--- a/k2/csrc/cuda/array.h
+++ b/k2/csrc/cuda/array.h
@@ -77,6 +77,8 @@ class Array1 {
 
   ContextPtr &Context() { return region_->context; }
 
+  const ContextPtr &Context() const { return region_->context; }
+
   // Sets the context on this object (Caution: this is not something you'll
   // often need).  'ctx' must be compatible with the current Context(),
   // i.e. `ctx->IsCompatible(*Context())`, and is expected to be a parent of
@@ -95,7 +97,7 @@ class Array1 {
   T operator[](int32_t i);
 
   Array1 operator[](const Array1<int32_t> &indexes) {
-    assert(Context()->IsCompatible(indexes.GetContext()));
+    assert(Context()->IsCompatible(*indexes.Context()));
     int32_t ret_dim = indexes.Dim();
     Array1<T> ans(Context(), ret_dim);
     const T *this_data = Data();

--- a/k2/csrc/cuda/ops.h
+++ b/k2/csrc/cuda/ops.h
@@ -76,8 +76,8 @@ __global__ void TransposeKernel(int32_t rows, int32_t cols, const T *input,
  */
 template <typename T>
 void Transpose(ContextPtr &c, const Array2<T> &src, Array2<T> *dest) {
-  assert(c.IsCompatible(src.Context()));
-  assert(c.IsCompatible(dest->Context()));
+  assert(c->IsCompatible(*src.Context()));
+  assert(c->IsCompatible(*dest->Context()));
   int32_t rows = src.Dim0();
   int32_t cols = src.Dim1();
   // TODO(haowen): limit the number of elements?


### PR DESCRIPTION
* Fix syntax error of ops_test.cu

* Add a const version of k2::Array1::Context to fix quantifier error of array.h