### PR TITLE
update to review

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,33 +43,46 @@ if(WIN32 AND BUILD_SHARED_LIBS)
   set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
 endif()
 
-# the following settings are modified from cub/CMakeLists.txt
-#[[ start settings for CUB ]]
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.18.0")
+  find_package(CUDAToolkit REQUIRED)
+  if(CUDAToolkit_FOUND)
+    message(STATUS "found CUDAToolkit " ${CUDAToolkit_LIBRARY_DIR})
+    message(STATUS "CUDAToolkit_INCLUDE_DIRS " ${CUDAToolkit_INCLUDE_DIRS})
+    message(STATUS "CUDAToolkit_LIBRARY_DIR " ${CUDAToolkit_LIBRARY_DIR})
 
-set(CMAKE_CXX_STANDARD 11 CACHE STRING "The C++ version to be used.")
-set(CMAKE_CXX_EXTENSIONS OFF)
+    enable_language(CUDA)
 
-message(STATUS "C++ Standard version: ${CMAKE_CXX_STANDARD}")
+    # With many architectures set here, the nvcc build time would be much longer.
+    # Thus, "61" is put here for speed and compatibility.
+    # @ToDo Need to cover more architectures, before release these code.
+    set(CMAKE_CUDA_ARCHITECTURES 61)
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda")
+  endif()
+else()
+  # the following settings are modified from cub/CMakeLists.txt
+  set(CMAKE_CXX_STANDARD 11 CACHE STRING "The C++ version to be used.")
+  set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Force CUDA C++ standard to be the same as the C++ standard used.
-#
-# Now, CMake is unaligned with reality on standard versions: https://gitlab.kitware.com/cmake/cmake/issues/18597
-# which means that using standard CMake methods, it's impossible to actually sync the CXX and CUDA versions for pre-11
-# versions of C++; CUDA accepts 98 but translates that to 03, while CXX doesn't accept 03 (and doesn't translate that to 03).
-# In case this gives You, dear user, any trouble, please escalate the above CMake bug, so we can support reality properly.
-if(DEFINED CMAKE_CUDA_STANDARD)
-  message(WARNING "You've set CMAKE_CUDA_STANDARD; please note that this variable is ignored, and CMAKE_CXX_STANDARD"
-    " is used as the C++ standard version for both C++ and CUDA.")
+  message(STATUS "C++ Standard version: ${CMAKE_CXX_STANDARD}")
+
+  # Force CUDA C++ standard to be the same as the C++ standard used.
+  #
+  # Now, CMake is unaligned with reality on standard versions: https://gitlab.kitware.com/cmake/cmake/issues/18597
+  # which means that using standard CMake methods, it's impossible to actually sync the CXX and CUDA versions for pre-11
+  # versions of C++; CUDA accepts 98 but translates that to 03, while CXX doesn't accept 03 (and doesn't translate that to 03).
+  # In case this gives You, dear user, any trouble, please escalate the above CMake bug, so we can support reality properly.
+  if(DEFINED CMAKE_CUDA_STANDARD)
+    message(WARNING "You've set CMAKE_CUDA_STANDARD; please note that this variable is ignored, and CMAKE_CXX_STANDARD"
+      " is used as the C++ standard version for both C++ and CUDA.")
+  endif()
+  unset(CMAKE_CUDA_STANDARD CACHE)
+  set(CMAKE_CUDA_STANDARD ${CMAKE_CXX_STANDARD})
+
+  set(K2_COMPUTE_ARCHS 30 32 35 50 52 53 60 61 62 70 72)
+  foreach(COMPUTE_ARCH IN LISTS K2_COMPUTE_ARCHS)
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda -gencode arch=compute_${COMPUTE_ARCH},code=sm_${COMPUTE_ARCH}")
+  endforeach()
 endif()
-unset(CMAKE_CUDA_STANDARD CACHE)
-set(CMAKE_CUDA_STANDARD ${CMAKE_CXX_STANDARD})
-
-set(K2_COMPUTE_ARCHS 30 32 35 50 52 53 60 61 62 70 72)
-foreach(COMPUTE_ARCH IN LISTS K2_COMPUTE_ARCHS)
-  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda -gencode arch=compute_${COMPUTE_ARCH},code=sm_${COMPUTE_ARCH}")
-endforeach()
-
-#[[ end settings for CUB ]]
 
 enable_testing()
 

--- a/k2/csrc/cuda/debug.h
+++ b/k2/csrc/cuda/debug.h
@@ -127,7 +127,7 @@ __host__ __device__ __forceinline__ cudaError_t K2CudaDebug_(
 }
 
 /**
- * @def K2_CUDA_PRINT_ERROR(cudaError)
+ * @def K2_CUDA_CHECK_ERROR(cudaError)
  *
  * @brief Macro for checking cuda error.
  *
@@ -140,10 +140,10 @@ __host__ __device__ __forceinline__ cudaError_t K2CudaDebug_(
  * @return      the CUDA error returned by `K2CudaDebug_`.
  *
  * @code{.cpp}
- * K2_CUDA_PRINT_ERROR(error = cudaGetLastError());
+ * K2_CUDA_CHECK_ERROR(error = cudaGetLastError());
  * @endcode
  */
-#define K2_CUDA_PRINT_ERROR(e, bAbort...)                            \
+#define K2_CUDA_CHECK_ERROR(e, bAbort...)                            \
   ::k2::K2CudaDebug_((cudaError_t)(e), __FILE__, __LINE__, ##bAbort)
 
 /**
@@ -154,7 +154,7 @@ __host__ __device__ __forceinline__ cudaError_t K2CudaDebug_(
  *
  * @details
  *  - The `cudaDeviceSynchronize` only happens when `NDEBUG` is not defined.
- *  - Use K2_CUDA_PRINT_ERROR(.., bAbort = true) to deal with the error.
+ *  - Use K2_CUDA_CHECK_ERROR(.., bAbort = true) to deal with the error.
  *
  * @param[in]
  *
@@ -172,13 +172,13 @@ __host__ __device__ __forceinline__ cudaError_t K2CudaDebug_(
     do {                                             \
       (__VA_ARGS__);                                 \
       cudaDeviceSynchronize();                       \
-      K2_CUDA_PRINT_ERROR(cudaGetLastError(), true); \
+      K2_CUDA_CHECK_ERROR(cudaGetLastError(), true); \
     } while (0)
 #else
   #define K2_CUDA_SAFE_CALL(...)                     \
     do {                                             \
       (__VA_ARGS__);                                 \
-      K2_CUDA_PRINT_ERROR(cudaGetLastError(), true); \
+      K2_CUDA_CHECK_ERROR(cudaGetLastError(), true); \
     } while (0)
 #endif
 

--- a/k2/csrc/cuda/debug_test.cu
+++ b/k2/csrc/cuda/debug_test.cu
@@ -80,7 +80,7 @@ TEST(DebugTest, K2CheckEq) {
 
 TEST(DebugTest, K2CudaCheckError) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-  ASSERT_DEATH(K2_CUDA_PRINT_ERROR(cudaErrorMemoryAllocation, true),
+  ASSERT_DEATH(K2_CUDA_CHECK_ERROR(cudaErrorMemoryAllocation, true),
                "cudaErrorMemoryAllocation");
 }
 
@@ -128,7 +128,7 @@ TEST(DebugTest, K2DLog) {
     HelloCUDA<<<1, 5>>>(1.2345f);
     FillContents<<<3, 2>>>(1, d_A);
     cudaDeviceSynchronize();
-    auto error = K2_CUDA_PRINT_ERROR(cudaGetLastError());
+    auto error = K2_CUDA_CHECK_ERROR(cudaGetLastError());
     EXPECT_EQ(error, cudaSuccess);
   }
 


### PR DESCRIPTION
- fix a twice error code checking issue
- change macro name `K2_CUDA_CHECK_ERROR` to `K2_CUDA_PRINT_ERROR` as its effect
- add a optional arg `abort` to control abort if hit error
- trivals

